### PR TITLE
Add web app prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# 301Co
+# 301Co App
+
+This repository contains a minimal prototype web application based on the feature list provided.
+It is a static HTML/JavaScript demonstration that shows the overall layout of the app with
+navigation tabs and placeholder content.
+
+## Usage
+
+Open `index.html` in a browser to view the app. The app does not require a backend.
+
+## Development
+
+JavaScript and CSS files are located in the repository root. Modify them to adjust the
+behavior or styling of the prototype.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>301Co App Prototype</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <div class="header-left" id="messages">💬</div>
+        <div class="header-center">Logo</div>
+        <div class="header-right">
+            <select id="settings">
+                <option value="">Settings</option>
+                <option value="away">Away Message</option>
+                <option value="theme">Theme</option>
+                <option value="notifications">Notifications</option>
+            </select>
+        </div>
+    </header>
+    <nav>
+        <button data-page="home" class="active">Home</button>
+        <button data-page="clients">Active Clients</button>
+        <button data-page="forms">Blank Forms</button>
+        <button data-page="insurance">Insurance & Docs</button>
+        <button data-page="tools">Tool Bag</button>
+        <button data-page="comms">Phone/Email</button>
+    </nav>
+    <main>
+        <section id="home" class="page active">
+            <div id="quote">"Stay positive!"</div>
+            <div id="calendar">Weekly calendar goes here.</div>
+            <div class="hot-buttons">
+                <button id="scanner">📷 Open Scanner</button>
+                <button id="new-client">📁 Create New Client File</button>
+            </div>
+        </section>
+        <section id="clients" class="page">
+            <h2>Active Client Files</h2>
+            <div class="content">Client list placeholder.</div>
+        </section>
+        <section id="forms" class="page">
+            <h2>Blank Forms</h2>
+            <div class="content">Form index placeholder.</div>
+        </section>
+        <section id="insurance" class="page">
+            <h2>Insurance & Documentation</h2>
+            <div class="content">Insurance documents placeholder.</div>
+        </section>
+        <section id="tools" class="page">
+            <h2>Tool Bag</h2>
+            <div class="content">Widgets go here.</div>
+        </section>
+        <section id="comms" class="page">
+            <h2>Phone & Email</h2>
+            <div class="content">Communication shortcuts placeholder.</div>
+        </section>
+    </main>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,18 @@
+// Simple navigation logic
+const navButtons = document.querySelectorAll('nav button');
+const pages = document.querySelectorAll('.page');
+
+navButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+        // set active button
+        navButtons.forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        // show selected page
+        const pageId = btn.getAttribute('data-page');
+        pages.forEach(p => p.classList.remove('active'));
+        document.getElementById(pageId).classList.add('active');
+    });
+});
+
+// Placeholder features for future implementation
+console.log('Prototype loaded');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "301co",
+  "version": "1.0.0",
+  "description": "This repository contains a minimal prototype web application based on the feature list provided. It is a static HTML/JavaScript demonstration that shows the overall layout of the app with navigation tabs and placeholder content.",
+  "main": "main.js",
+  "scripts": {
+    "test": "echo \"No tests specified\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,45 @@
+body {
+    font-family: Arial, sans-serif;
+    background: white;
+    color: black;
+    margin: 0;
+}
+header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px;
+    background-color: #1f2d3d; /* navy */
+    color: white;
+}
+nav {
+    display: flex;
+    background: #f0f0f0;
+    padding: 5px;
+}
+nav button {
+    margin-right: 5px;
+    padding: 10px;
+    border: none;
+    background: #e0e0e0;
+    cursor: pointer;
+}
+nav button.active {
+    background: #1f2d3d;
+    color: white;
+}
+main {
+    padding: 20px;
+}
+.page {
+    display: none;
+}
+.page.active {
+    display: block;
+}
+.hot-buttons {
+    margin-top: 10px;
+}
+.hot-buttons button {
+    margin-right: 10px;
+}


### PR DESCRIPTION
## Summary
- build a minimal app prototype with navigation tabs and placeholder pages
- add styling for header, nav, and pages
- implement simple JavaScript navigation logic
- document how to run the prototype

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68584ffbd61883238558e624dc6ae8d5